### PR TITLE
perf: use Realtime database in place of Firestore database

### DIFF
--- a/frontend/src/routes/eventlogs/+page.svelte
+++ b/frontend/src/routes/eventlogs/+page.svelte
@@ -13,6 +13,11 @@
     import { firestore } from "$lib/firebase";
 
     const sortEntriesByTime = query(collection(firestore, 'sensorData'),  orderBy('time'), limit(25));
+    
+    const source = new EventSource("https://smoketrace-api.deno.dev/sensors");
+    source.onmessage = (event) => {
+        console.log(event.data);
+    }
 </script>
 
 <div>
@@ -22,7 +27,7 @@
 		[Contains significant smoke readings and sensor health reports]
 	</p>
 
-    <FirebaseApp {auth} {firestore}>
+    <!-- <FirebaseApp {auth} {firestore}>
         <Collection
             ref={sortEntriesByTime}
             let:data
@@ -41,5 +46,5 @@
             {/if}
             <span slot="loading">Fetching data...</span>
         </Collection>
-    </FirebaseApp>
+    </FirebaseApp> -->
 </div>

--- a/frontend/src/routes/eventlogs/+page.ts
+++ b/frontend/src/routes/eventlogs/+page.ts
@@ -3,6 +3,7 @@ import { dev } from '$app/environment';
 // we don't need any JS on this page, though we'll load
 // it in dev so that we get hot module replacement
 export const csr = dev;
+export const ssr = false;
 
 // since there's no dynamic data here, we can prerender
 // it so that it gets served as a static asset in production


### PR DESCRIPTION
Adjust `GET /sensors` to redirect to `sensorData` stored in Realtime database.

Attempts to solve #31.