### PR TITLE
feat(frontend): display event log

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -875,9 +875,9 @@
 			"dev": true
 		},
 		"node_modules/@fontsource/merriweather": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@fontsource/merriweather/-/merriweather-5.0.1.tgz",
-			"integrity": "sha512-yEls56g2NQckvL4f+TM+ZobENndcET5CPVh63ydTZEkXF/YgI8dliDnT2xi4D9G1p8eBmvLzdxhT9gF9bgfmfw==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@fontsource/merriweather/-/merriweather-5.0.2.tgz",
+			"integrity": "sha512-xoziTXfksJCNnyV12IIR1/5NpEN062I1XqVEOf97snw0OxsvXAZ2TiWxJL+wxSbGxZiXIu3zDSBp9nkoxRSKHw==",
 			"dev": true
 		},
 		"node_modules/@grpc/grpc-js": {
@@ -1157,34 +1157,6 @@
 				}
 			}
 		},
-		"node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@rollup/plugin-commonjs/node_modules/glob": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^5.0.1",
-				"once": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
@@ -1195,18 +1167,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@rollup/plugin-json": {
@@ -1230,9 +1190,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.2.tgz",
-			"integrity": "sha512-Y35fRGUjC3FaurG722uhUuG8YHOJRJQbI6/CkbRkdPotSpDj9NtIN85z1zrcyDcCQIW4qp5mgG72U+gJ0TAFEg==",
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
+			"integrity": "sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^5.0.1",
@@ -1289,13 +1249,13 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.18.0.tgz",
-			"integrity": "sha512-QE5X9gCG34khrO6j01ZbRXtVx+yyUNe8PmVPeG0M+I8eyFejqYMEhD1JtjCrLzpd4KukvuO8bL35M1VWmPM7hQ==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.20.2.tgz",
+			"integrity": "sha512-MtR1i+HtmYWcRgtubw1GQqT/+CWXL/z24PegE0xYAdObbhdr7YtEfmoe705D/JZMtMmoPXrmSk4W0MfL5A3lYw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^2.1.1",
+				"@sveltejs/vite-plugin-svelte": "^2.4.1",
 				"@types/cookie": "^0.5.1",
 				"cookie": "^0.5.0",
 				"devalue": "^4.3.1",
@@ -1316,17 +1276,17 @@
 				"node": "^16.14 || >=18"
 			},
 			"peerDependencies": {
-				"svelte": "^3.54.0",
+				"svelte": "^3.54.0 || ^4.0.0-next.0",
 				"vite": "^4.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.3.0.tgz",
-			"integrity": "sha512-NbgDn5/auWfGYFip7DheDj49/JLE6VugdtdLJjnQASYxXqrQjl81xaZzQsoSAxWk+j2mOkmPFy56gV2i63FUnA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.4.1.tgz",
+			"integrity": "sha512-bNNKvoRY89ptY7udeBSCmTdCVwkjmMcZ0j/z9J5MuedT8jPjq0zrknAo/jF1sToAza4NVaAgR9AkZoD9oJJmnA==",
 			"dev": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte-inspector": "^1.0.1",
+				"@sveltejs/vite-plugin-svelte-inspector": "^1.0.2",
 				"debug": "^4.3.4",
 				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
@@ -1338,14 +1298,14 @@
 				"node": "^14.18.0 || >= 16"
 			},
 			"peerDependencies": {
-				"svelte": "^3.54.0",
+				"svelte": "^3.54.0 || ^4.0.0-next.0",
 				"vite": "^4.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.1.tgz",
-			"integrity": "sha512-8ZXgDbAL1b2o7WHxnPsbkxTzZiZhMwOsCI/GFti3zFlh8unqJtUsgwRQV/XSULFcqkbZXz5v6MqMLSUpl3VKaA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.2.tgz",
+			"integrity": "sha512-Cy1dUMcYCnDVV/hPLXa43YZJ2jGKVW5rA0xuNL9dlmYhT0yoS1g7+FOFSRlgk0BXKk/Oc7grs+8BVA5Iz2fr8A==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4"
@@ -1355,7 +1315,7 @@
 			},
 			"peerDependencies": {
 				"@sveltejs/vite-plugin-svelte": "^2.2.0",
-				"svelte": "^3.54.0",
+				"svelte": "^3.54.0 || ^4.0.0-next.0",
 				"vite": "^4.0.0"
 			}
 		},
@@ -1453,13 +1413,12 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
@@ -1827,20 +1786,19 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
 			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -2107,15 +2065,15 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dev": true,
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=10"
 			}
 		},
 		"node_modules/minimist": {
@@ -2273,9 +2231,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.23",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-			"integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+			"version": "8.4.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+			"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2413,10 +2371,52 @@
 				"rimraf": "bin.js"
 			}
 		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/rollup": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.0.tgz",
-			"integrity": "sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==",
+			"version": "3.24.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.24.0.tgz",
+			"integrity": "sha512-OgraHOIg2YpHQTjl0/ymWfFNBEyPucB7lmhXrQUh38qNOegxLapSPFs9sNr0qKR75awW41D93XafoR2QfhBdUQ==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -2621,9 +2621,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.3.2.tgz",
-			"integrity": "sha512-67j3rI0LDc2DvL0ON/2pvCasVVD3nHDrTkZNr4eITNfo2oFXdw7SIyMOiFj4swu+pjmFQAigytBK1IWyik8dBw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.4.3.tgz",
+			"integrity": "sha512-O07soQFY3X0VDt+bcGc6D5naz0cLtjwnmNP9JsEBPVyMemFEqUhL2OdLqvkl5H/u8Jwm50EiAU4BPRn5iin/kg==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -2639,25 +2639,25 @@
 				"svelte-check": "bin/svelte-check"
 			},
 			"peerDependencies": {
-				"svelte": "^3.55.0"
+				"svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0"
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
-			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.2.tgz",
+			"integrity": "sha512-q/bAruCvFLwvNbeE1x3n37TYFb3mTBJ6TrCq6p2CoFbSTNhDE9oAtEfpy+wmc9So8AG0Tja+X0/mJzX9tSfvIg==",
 			"dev": true,
 			"engines": {
 				"node": "^12.20 || ^14.13.1 || >= 16"
 			},
 			"peerDependencies": {
-				"svelte": ">=3.19.0"
+				"svelte": "^3.19.0 || ^4.0.0-next.0"
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.3.tgz",
-			"integrity": "sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.4.tgz",
+			"integrity": "sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -2680,7 +2680,7 @@
 				"sass": "^1.26.8",
 				"stylus": "^0.55.0",
 				"sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-				"svelte": "^3.23.0",
+				"svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0",
 				"typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -2770,21 +2770,21 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"node_modules/tslib": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
 		},
 		"node_modules/typescript": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+			"integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=12.20"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/undici": {
@@ -2800,9 +2800,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.8.tgz",
-			"integrity": "sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+			"integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.17.5",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,12 @@
 			"name": "smoketrace",
 			"version": "0.0.1",
 			"dependencies": {
+				"@fortawesome/fontawesome-svg-core": "^6.4.0",
+				"@fortawesome/free-brands-svg-icons": "^6.4.0",
+				"@fortawesome/free-regular-svg-icons": "^6.4.0",
+				"@fortawesome/free-solid-svg-icons": "^6.4.0",
 				"firebase": "^9.22.1",
+				"svelte-fa": "^3.0.4",
 				"sveltefire": "^0.2.3"
 			},
 			"devDependencies": {
@@ -879,6 +884,63 @@
 			"resolved": "https://registry.npmjs.org/@fontsource/merriweather/-/merriweather-5.0.2.tgz",
 			"integrity": "sha512-xoziTXfksJCNnyV12IIR1/5NpEN062I1XqVEOf97snw0OxsvXAZ2TiWxJL+wxSbGxZiXIu3zDSBp9nkoxRSKHw==",
 			"dev": true
+		},
+		"node_modules/@fortawesome/fontawesome-common-types": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+			"integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+			"hasInstallScript": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/fontawesome-svg-core": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+			"integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "6.4.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-brands-svg-icons": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.0.tgz",
+			"integrity": "sha512-qvxTCo0FQ5k2N+VCXb/PZQ+QMhqRVM4OORiO6MXdG6bKolIojGU/srQ1ptvKk0JTbRgaJOfL2qMqGvBEZG7Z6g==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "6.4.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-regular-svg-icons": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+			"integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "6.4.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-solid-svg-icons": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+			"integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "6.4.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/@grpc/grpc-js": {
 			"version": "1.7.3",
@@ -2641,6 +2703,11 @@
 			"peerDependencies": {
 				"svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0"
 			}
+		},
+		"node_modules/svelte-fa": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/svelte-fa/-/svelte-fa-3.0.4.tgz",
+			"integrity": "sha512-y04vEuAoV1wwVDItSCzPW7lzT6v1bj/y1p+W1V+NtIMpQ+8hj8MBkx7JFD7JHSnalPU1QiI8BVfguqheEA3nPg=="
 		},
 		"node_modules/svelte-hmr": {
 			"version": "0.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,12 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@fortawesome/fontawesome-svg-core": "^6.4.0",
+		"@fortawesome/free-brands-svg-icons": "^6.4.0",
+		"@fortawesome/free-regular-svg-icons": "^6.4.0",
+		"@fortawesome/free-solid-svg-icons": "^6.4.0",
 		"firebase": "^9.22.1",
+		"svelte-fa": "^3.0.4",
 		"sveltefire": "^0.2.3"
 	}
 }

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -9,4 +9,8 @@ declare global {
 	}
 }
 
+declare module '@fortawesome/pro-solid-svg-icons/index.es' {
+  export * from '@fortawesome/pro-solid-svg-icons';
+}
+
 export {};

--- a/frontend/src/lib/components/SmokeLogItem.svelte
+++ b/frontend/src/lib/components/SmokeLogItem.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    export let seconds: number;
+    export let device_id: string;
+    export let smoke_read: number;
+
+    let timestamp = new Date(seconds).toLocaleString();
+
+    // Temporary thresholds for now; can adjust later.
+    function generateMsg(smoke_read: number) {
+        if (smoke_read < 0)
+            return null;
+        if (smoke_read < 100)
+            return 'LOW smoke warning';
+        if (smoke_read < 400)
+            return 'MEDIUM smoke warning';
+
+       return 'HIGH smoke warning';
+    }
+</script>
+
+<li>
+    <span class="dot"></span>
+    <p>{timestamp}</p>
+    <h3>{generateMsg(smoke_read)}</h3>
+    <p>{device_id} detected smoke level {smoke_read}</p>
+</li>
+
+<style>
+
+</style>

--- a/frontend/src/lib/components/SmokeLogItem.svelte
+++ b/frontend/src/lib/components/SmokeLogItem.svelte
@@ -3,23 +3,14 @@
     export let device_id: string;
     export let smoke_read: number;
 
-    let timestamp = new Date(seconds).toLocaleString();
+    let timestamp = new Date(seconds*1000).toLocaleString();
 
-    // Temporary thresholds for now; can adjust later.
-    function generateMsg(smoke_read: number) {
-        if (smoke_read < 0)
-            return null;
-        if (smoke_read < 384)
-            return "Smoke warning: LOW";
-
-        return "Smoke warning: HIGH";
-    }
 </script>
 
 <li>
     <span class="dot"></span>
     <p>{timestamp}</p>
-    <h3>{generateMsg(smoke_read)}</h3>
+    <h3>Smoke warning: HIGH</h3>
     <p>{device_id} detected smoke level {smoke_read}</p>
 </li>
 

--- a/frontend/src/lib/components/SmokeLogItem.svelte
+++ b/frontend/src/lib/components/SmokeLogItem.svelte
@@ -9,12 +9,10 @@
     function generateMsg(smoke_read: number) {
         if (smoke_read < 0)
             return null;
-        if (smoke_read < 100)
-            return 'LOW smoke warning';
-        if (smoke_read < 400)
-            return 'MEDIUM smoke warning';
+        if (smoke_read < 384)
+            return "Smoke warning: LOW";
 
-       return 'HIGH smoke warning';
+        return "Smoke warning: HIGH";
     }
 </script>
 

--- a/frontend/src/routes/eventlogs/+page.svelte
+++ b/frontend/src/routes/eventlogs/+page.svelte
@@ -6,6 +6,9 @@
 <script lang="ts">
 	import { onDestroy, onMount } from 'svelte';
 
+    import Fa from 'svelte-fa/src/fa.svelte';
+    import { faFire } from '@fortawesome/free-solid-svg-icons'
+
     import SmokeLogItem from '../../lib/components/SmokeLogItem.svelte';
 
     let source: EventSource;
@@ -54,6 +57,8 @@
 </script>
 
 <div>
+
+    <Fa icon={faFire} />
 	<h1>Incident Logs</h1>
 
 	<p>

--- a/frontend/src/routes/eventlogs/+page.svelte
+++ b/frontend/src/routes/eventlogs/+page.svelte
@@ -4,7 +4,9 @@
 </svelte:head>
 
 <script lang="ts">
-	import { onDestroy, onMount } from "svelte";
+	import { onDestroy, onMount } from 'svelte';
+
+    import SmokeLogItem from '../../lib/components/SmokeLogItem.svelte';
 
     let source: EventSource;
     const apiUrl = "https://smoketrace-api.deno.dev/sensors";
@@ -61,12 +63,19 @@
     {#if data === undefined}
         <em>Waiting for data...</em>
     {:else}
-        {#each data as {device_id, smoke_read, time}}
-            {#if smoke_read > 0}
-                {@const timestamp = new Date(time.seconds).toLocaleString()}
-                {timestamp} : {device_id} detected smoke level {smoke_read}
-                <br>
-            {/if}
-        {/each}
+        <ul class="logs">
+            {#each data as {device_id, smoke_read, time}}
+                {#if smoke_read > 0}
+                    <SmokeLogItem seconds={time.seconds} {device_id} {smoke_read} />
+                    <br>
+                {/if}
+            {/each}
+        </ul>
     {/if}
 </div>
+
+<style>
+    .logs {
+        border-left: 1.5px solid var(--smoke-beige);
+    }
+</style>

--- a/frontend/src/routes/eventlogs/+page.svelte
+++ b/frontend/src/routes/eventlogs/+page.svelte
@@ -74,7 +74,7 @@
     {:else}
         <ul class="logs">
             {#each processed_data as {device_id, smoke_read, time}}
-                {#if smoke_read > 0}
+                {#if smoke_read >= 384}
                     <SmokeLogItem seconds={time.seconds} {device_id} {smoke_read} />
                     <br>
                 {/if}

--- a/frontend/src/routes/eventlogs/+page.svelte
+++ b/frontend/src/routes/eventlogs/+page.svelte
@@ -58,24 +58,15 @@
 		[Contains significant smoke readings and sensor health reports]
 	</p>
 
-    <!-- <FirebaseApp {auth} {firestore}>
-        <Collection
-            ref={sortEntriesByTime}
-            let:data
-            let:count
-        >
-            {#if count == 0}
-                <span>Waiting for new data...</span>
-            {:else}
-                <p>Showing {count} entries (in the future, allow view entries from the past hour, day, week)</p>
-                {#each data as smokeReading}
-                    {#if smokeReading.smoke_read > 0}
-                        {new Date((smokeReading.time.seconds)*1000).toLocaleString()} - {smokeReading.device_id} detected smoke level {smokeReading.smoke_read}
-                        <hr>
-                    {/if}
-                {/each}
+    {#if data === undefined}
+        <em>Waiting for data...</em>
+    {:else}
+        {#each data as {device_id, smoke_read, time}}
+            {#if smoke_read > 0}
+                {@const timestamp = new Date(time.seconds).toLocaleString()}
+                {timestamp} : {device_id} detected smoke level {smoke_read}
+                <br>
             {/if}
-            <span slot="loading">Fetching data...</span>
-        </Collection>
-    </FirebaseApp> -->
+        {/each}
+    {/if}
 </div>

--- a/frontend/src/routes/styles.css
+++ b/frontend/src/routes/styles.css
@@ -1,37 +1,37 @@
 @font-face {
 	font-family: 'Roboto';
-	src: url("../../static/fonts/Roboto-Regular.woff2");
+	src: url("/fonts/Roboto-Regular.woff2");
 	font-weight: 400;
 }
 
 @font-face {
 	font-family: 'Roboto';
-	src: url("../../static/fonts/Roboto-Light.woff2");
+	src: url("/fonts/Roboto-Light.woff2");
 	font-weight: 300;
 }
 
 @font-face {
 	font-family: 'Roboto';
-	src: url("../../static/fonts/Roboto-Bold.woff2");
+	src: url("/fonts/Roboto-Bold.woff2");
 	font-weight: 700;
 }
 
 @font-face {
 	font-family: 'Poppins';
-	src: url("../../static/fonts/Poppins-Bold.woff2");
+	src: url("/fonts/Poppins-Bold.woff2");
 	font-weight: 700;
 }
 
 @font-face {
 	font-family: 'Roboto Mono';
-	src: url("../../static/fonts/RobotoMono-ExtraLightItalic.woff2");
+	src: url("/fonts/RobotoMono-ExtraLightItalic.woff2");
 	font-weight: 100;
 	font-style: italic;
 }
 
 @font-face {
 	font-family: 'Roboto Mono';
-	src: url("../../static/fonts/RobotoMono-Light.woff2");
+	src: url("/fonts/RobotoMono-Light.woff2");
 	font-weight: 300;
 }
 


### PR DESCRIPTION
## 📋`frontend-logs` version 2!
Updates from the API are streamed automatically to the client through [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events).

Logged entries show a timestamp, `device_id` and the smoke reading.
Sample:
```
12/11/1973, 7:01:17 AM : ESP32-JOY detected smoke level 500
```
Entries are shown most-recent-first, excluding readings with a 0 value.

The logs are currently fully-functional, but I will be marking this PR as draft since I aim to make the display look more presentable first. ^^

## 🔨Next to implement
- [ ] Device status

## 🐛Bugs to fix in the future...
- connection to the server doesn't seem to get closed by `.close()`