### PR TITLE
fix: change SSE return type for `GET /sensors` as array of values

### DIFF
--- a/backend/deno/api.ts
+++ b/backend/deno/api.ts
@@ -89,8 +89,9 @@ router
             const target = context.sendEvents();
             const sensor_ref = query(ref(real_db, 'sensorData'), orderByChild("time"), limitToLast(25));
             onValue(sensor_ref, (snapshot) => {
-                console.log(snapshot.val());
-                target.dispatchMessage(snapshot.val());
+                const array = Object.values(snapshot.val());
+                console.log(array);
+                target.dispatchMessage(array);
             });
         } catch (e) {
             console.log(e);

--- a/backend/deno/local_api.ts
+++ b/backend/deno/local_api.ts
@@ -93,8 +93,9 @@ router
             const target = context.sendEvents();
             const sensor_ref = query(ref(real_db, 'sensorData'), orderByChild("time"), limitToLast(25));
             onValue(sensor_ref, (snapshot) => {
-                console.log(snapshot.val());
-                target.dispatchMessage(snapshot.val());
+                const array = Object.values(snapshot.val());
+                console.log(array);
+                target.dispatchMessage(array);
             });
         } catch (e) {
             console.log(e);


### PR DESCRIPTION
Change SSE return type to usual `array` of last 25 smoke data.